### PR TITLE
fix: add required permissions and bump python version up to 3.9

### DIFF
--- a/automated-archive-restore-and-copy-solution-latest.yaml
+++ b/automated-archive-restore-and-copy-solution-latest.yaml
@@ -706,6 +706,7 @@ Resources:
                   - 's3:GetObjectVersion'
                   - 's3:GetBucketLocation'
                   - 's3:PutObject'
+                  - 's3:ListBucket'
                 Resource:
                   - !Sub arn:${AWS::Partition}:s3:::${S3AutoRestoreMigrateS3Bucket}
                   - !Sub arn:${AWS::Partition}:s3:::${S3AutoRestoreMigrateS3Bucket}/*
@@ -2412,7 +2413,7 @@ Resources:
           copy_metadata: !Ref CopyMetadata
           copy_tagging: !Ref CopyTagging
           copy_storage_class: !Ref StorageClass
-      Runtime: python3.8
+      Runtime: python3.9
       Timeout: 900
       Description: An S3 Batch Solution for Copying above 5GB S3 Object Size.
       MemorySize: 600


### PR DESCRIPTION
*Description of changes:*
* fix: add required permissions to the IAM Role S3BatchOperationsServiceIamRole
* chore: bump python version up to 3.9 for the S3BatchCopyLambdafunction function, as Python 3.8 is no longer supported by AWS.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
